### PR TITLE
FIX calculation of t, e.g. using 1048576 i.e. 2^20 causes an overflow…

### DIFF
--- a/si5351/si5351.c
+++ b/si5351/si5351.c
@@ -261,9 +261,7 @@ void si5351_Calc(int32_t Fclk, si5351PLLConfig_t* pll_conf, si5351OutputConfig_t
         x = Fpll/Fclk;
         // t = ceil(Fclk/0xFFFFF)
         t = Fclk >> 20;
-        if(Fclk & 0xFFFFF) {
-            t += 1;
-        }
+        t = (Fxtal >> 20) + 1;
         y = (Fpll % Fclk) / t;
         z = Fclk / t;
     } else {
@@ -282,9 +280,7 @@ void si5351_Calc(int32_t Fclk, si5351PLLConfig_t* pll_conf, si5351OutputConfig_t
         a = numerator/Fxtal;
         // t = ceil(Fxtal/0xFFFFF)
         t = Fxtal >> 20;
-        if(Fxtal & 0xFFFFF) {
-            t += 1;
-        }
+        t = (Fxtal >> 20) + 1;
         b = (numerator % Fxtal) / t;
         c = Fxtal / t;
     }


### PR DESCRIPTION
… for the register using z.
When using your calculation for instance with correction `si5351Correction` set to 0 and given exactly the frequency value of 2^20 that is 1048576; that `value >> 20` gives exactly 1 but within the next line `if(Fclk & 0xFFFFF)` that fails and t remains 1.
So the z becomes 1048576 which is one bit too high :-)
I think you simply can replace it with a one liner:
`t = (Fxtal >> 20) + 1;` which correctly adds this for the divisor t

Thank you Aleksander for sharing your code. I just looked at it, but never installed it, because I definitely try to make a separate library with more then one instances. So I can drive several Si5351 on my STM32L4A6ZG ...
Thomas


 