### PR TITLE
Fix Fclk instead of Fxtal

### DIFF
--- a/si5351/si5351.c
+++ b/si5351/si5351.c
@@ -259,7 +259,7 @@ void si5351_Calc(int32_t Fclk, si5351PLLConfig_t* pll_conf, si5351OutputConfig_t
         c = 1;
         int32_t Fpll = 900000000;
         x = Fpll/Fclk;
-        t = (Fxtal >> 20) + 1;
+        t = (Fclk >> 20) + 1;
         y = (Fpll % Fclk) / t;
         z = Fclk / t;
     } else {


### PR DESCRIPTION
Unfortunately I copy/pasted the wrong line, there should be Fclk instead of Fxtal in line 259. Sorry my fault.
I didn't go through the code at line 278 upto 281; there is a similar calculation, but with Fxtal - is this okay there?


        // Valid for Fclk in 75..160 MHz range
        if(Fclk >= 150000000) {
            x = 4;
        } else if (Fclk >= 100000000) {
            x = 6;
        } else {
            x = 8;
        }
        y = 0;
        z = 1;

        int32_t numerator = xFclk;  // <<----
        a = numerator/Fxtal;  // <<--- Fclk ???
        t = (Fxtal >> 20) + 1;  // <<--- Fclk ???
        b = (numerator % Fxtal) / t;  // <<--- Fclk ???
        c = Fxtal / t;  // <<--- Fclk ???
